### PR TITLE
Ajoute le champ rawValue à champ inconnus

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -99,6 +99,15 @@ class Validator {
     this.validatedRows = this.parsedRows.map((row, line) => {
       row._line = line + 1
       row._errors = []
+
+      Object.keys(row).forEach(field => {
+        if (!Object.keys(schema.fields).includes(field.toLowerCase())) {
+          if (field !== '_line' && field !== '_errors') {
+            row[field] = {rawValue: row[field]}
+          }
+        }
+      })
+
       Object.keys(schema.fields).forEach(field => {
         // Deal with aliases
         if (field in this.aliasedFields) {
@@ -131,9 +140,11 @@ class Validator {
           row._errors = row._errors.concat(row[field].errors)
         }
       })
+
       const rowLevelErrors = schema.row(row)
       this.rowsErrorsCount += rowLevelErrors.length
       row._errors = row._errors.concat(rowLevelErrors)
+
       return row
     })
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -97,16 +97,15 @@ class Validator {
   validateRows() {
     this.rowsErrorsCount = 0
     this.validatedRows = this.parsedRows.map((row, line) => {
+      Object.keys(row).forEach(field => {
+        if (!Object.keys(schema.fields).includes(field.toLowerCase())) {
+          row[field] = {rawValue: row[field]}
+        }
+      })
+
       row._line = line + 1
       row._errors = []
 
-      Object.keys(row).forEach(field => {
-        if (!Object.keys(schema.fields).includes(field.toLowerCase())) {
-          if (field !== '_line' && field !== '_errors') {
-            row[field] = {rawValue: row[field]}
-          }
-        }
-      })
 
       Object.keys(schema.fields).forEach(field => {
         // Deal with aliases


### PR DESCRIPTION
Lorsqu'un champ est un inconnu sa valeur est renvoyée sous forme de string. Hors le modèle par défaut est un object contenant au moins `rawValue`.