### PR TITLE
Corrige les tests cassés par la gestion des champs inconnus

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -113,7 +113,11 @@ class Validator {
           delete row[this.aliasedFields[field]]
         }
 
-        const rawValue = row[field]
+        let rawValue = row[field]
+        if (row[field] && row[field].rawValue) {
+          rawValue = row[field].rawValue // unknowFields
+        }
+
         const def = schema.fields[field]
 
         if (def.required && !rawValue) {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -106,7 +106,6 @@ class Validator {
       row._line = line + 1
       row._errors = []
 
-
       Object.keys(schema.fields).forEach(field => {
         // Deal with aliases
         if (field in this.aliasedFields) {


### PR DESCRIPTION
La dernière PR permettant la prise en compte des champs inconnus transformée `rawValue` en object alors que `def.parse()`attendait une `string`.