### PR TITLE
Ajout du champ "certification_commune"

### DIFF
--- a/lib/schema/__tests__/index.js
+++ b/lib/schema/__tests__/index.js
@@ -30,3 +30,17 @@ test('validate cad_parcelles', t => {
   t.deepEqual(fields.cad_parcelles.parse('12345000AA0001|12345000AA0002', ctx2), ['12345000AA0001', '12345000AA0002'])
   t.deepEqual(ctx2.errors, [])
 })
+
+test('validate certification_commune', t => {
+  const ctx1 = createContext()
+  t.is(fields.certification_commune.parse('1', ctx1), true)
+  t.deepEqual(ctx1.errors, [])
+
+  const ctx2 = createContext()
+  t.is(fields.certification_commune.parse('0', ctx2), false)
+  t.deepEqual(ctx2.errors, [])
+
+  const ctx3 = createContext()
+  t.is(fields.certification_commune.parse('toto', ctx3), undefined)
+  t.deepEqual(ctx3.errors, ['valeur_invalide'])
+})

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -277,6 +277,22 @@ exports.fields = {
 
       return format(parsedDate, 'yyyy-MM-dd')
     }
+  },
+
+  certification_commune: {
+    required: false,
+    trim: true,
+    parse: (v, {addError}) => {
+      if (v === '1') {
+        return true
+      }
+
+      if (v === '0') {
+        return false
+      }
+
+      return addError('valeur_invalide')
+    }
   }
 
 }

--- a/lib/schema/profiles/1.2-etalab.js
+++ b/lib/schema/profiles/1.2-etalab.js
@@ -37,6 +37,7 @@ const warnings = [
   'source.valeur_manquante',
   'date_der_maj.valeur_manquante',
   'date_der_maj.date_invalide',
+  'certification_commune.valeur_invalide',
   'row.position_manquante',
   'row.chef_lieu_invalide',
   'field.suffixe.missing',

--- a/lib/validate/__tests__/index.js
+++ b/lib/validate/__tests__/index.js
@@ -59,7 +59,7 @@ test('validate a file with aliases', async t => {
     t.true(fields.some(f => f.schemaName === field))
   }
 
-  t.true(notFoundFields.length === 4)
+  t.true(notFoundFields.length === 5)
 
   for (const field of [
     'lieudit_complement_nom',
@@ -94,7 +94,7 @@ test('validate a file with aliases / strict mode', async t => {
 
   t.is(aliasedFields.length, 0)
   t.is(knownFields.length, 5)
-  t.is(notFoundFields.length, 13)
+  t.is(notFoundFields.length, 14)
   t.is(unknownFields.length, 9)
 })
 
@@ -106,5 +106,5 @@ test('validate a binary file', async t => {
 test('validate an arbitrary CSV file', async t => {
   const buffer = await readAsBuffer('junk.ascii.csv')
   const {notFoundFields} = await validate(buffer)
-  t.is(notFoundFields.length, 18)
+  t.is(notFoundFields.length, 19)
 })


### PR DESCRIPTION
Ajout d'un champ normalisé `certification_commune` optionnel, qui peut valoir `1` ou `0` (booléen).
Il permet d'expliciter si la commune a certifié cette adresse ou non.

Ce champ n'existe pas dans le format BAL AITF. Il s'agit d'un champ complémentaire proposé par la BAN.